### PR TITLE
Fix #29: restore SimpleSamlPHP's Exception

### DIFF
--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -186,6 +186,9 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
     drupal_load('module', 'field');
 
     chdir($a);
+
+    // Drupal's bootstrap overrides SimpleSamlPHP's exception handler.
+    restore_exception_handler();
   }
 
 

--- a/lib/Auth/Source/UserPass.php
+++ b/lib/Auth/Source/UserPass.php
@@ -131,6 +131,8 @@ class sspmod_drupalauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassBa
 		drupal_load('module', 'user');
 		drupal_load('module', 'field');
 
+		// Drupal's bootstrap overrides SimpleSamlPHP's exception handler.
+		restore_exception_handler();
 	}
 
 


### PR DESCRIPTION
Fix for https://github.com/Sanchiz/drupalauth/issues/29

This patch simply restore's the previous exception handler, which will be the one provided by SimpleSamlPHP.
