### PR TITLE
Do not throw exception on invalid cookies at the _start_ of auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+  "name": "drupalauth/simplesamlphp-module-drupalauth",
+  "description": "A SimpleSAMLphp module adding support for Drupal as the authentication source.",
+  "homepage": "https://github.com/drupalauth/simplesamlphp-module-drupalauth",
+  "type": "simplesamlphp-module",
+  "keywords": [
+    "SimpleSAMLphp",
+    "Drupal",
+    "Authentication"
+  ],
+  "license": "LGPL-2.1",
+  "authors": [
+    {
+      "name": "Steve Moitozo",
+      "email": "smoitozo@gmail.com"
+    },
+    {
+      "name": "Contributors",
+      "homepage": "https://github.com/drupalauth/simplesamlphp-module-drupalauth/graphs/contributors",
+      "role": "Contributors"
+    }
+  ],
+  "require": {
+    "simplesamlphp/simplesamlphp": "~1.0",
+    "simplesamlphp/composer-module-installer": "~1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5|^6"
+  },
+  "autoload-dev": {
+    "classmap": ["lib/", "tests/lib/"]
+  }
+}

--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -328,10 +328,11 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 
 		// Get user. If at this point a cookie is still present (which once was set
 		// by the drupal module), this may be from an older login attempt to another
-		// site that was terminated halfway - so delete the cookie if it's invalid
-		// instead of throwing an exception (which would likely make SimpleSAMLphp
-		// redirect back to the site with the exception message at this point,
-		// meaning any login attempts would fail until the cookie was deleted.)
+		// site that was terminated halfway. So if it's invalid, delete the cookie
+		// and continue to Drupal site for authentication (rather than throwing an
+		// exception, which would likely make SimpleSAMLphp redirect back to the
+		// SP with the exception message at this point, meaning any login attempts
+		// would fail until the cookie was deleted manually).
 		$attributes = $this->getUser(FALSE);
 		if ($attributes !== NULL) {
 			/*

--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -117,7 +117,7 @@ class External extends Source
      *
      * @return array|NULL  The user's attributes, or NULL if the user isn't authenticated.
      */
-    private function getUser($throw_on_invalid_cookie = TRUE)
+    private function getUser($throw_on_invalid_cookie = true)
     {
 
         $drupaluid = null;
@@ -181,7 +181,7 @@ class External extends Source
         // SimpleSAMLphp redirect back to the SP with the exception message at
         // this point, meaning any login attempts would fail until the cookie
         // was deleted manually).
-        $attributes = $this->getUser(TRUE);
+        $attributes = $this->getUser(true);
         if ($attributes !== null) {
             /*
              * The user is already authenticated.


### PR DESCRIPTION
*Summary:*

The authentication process hits SimpleSAMLphp / this module at two points in time. The first point is supposed to set a cookie, and the second point checks the cookie value to see if the requester is trying something strange. If invalid: it just throws an exception and the requester cannot continue.

So at the _first_ point, we expect no cookie to be set. If one _is_ set, then we can just ignore it and overwrite it.

The current code does not do that. As a consequence: if an invalid cookie is still presence in the user's browser, an exception is thrown and the user is (forever) stuck, on the first redirection to the IdP. That's a bug, IMHO.

----
Older text:

I typed this up for colleagues who didn't know the details of the auth process.

The login process, simplified for this purpose:
1. Site redirects from /saml/login to SimpleSAMLphp
2. SimpleSAMLphp loads drupalauth simplesaml-module for authentication checking, which checks "drupalauth4ssp" cookie.
2a. If cookie not present: redirects to the IdP (drupal site)
3. If the factory user is logged in / as soon as the IdP user has logged in using the normal login screen, the factory sets "drupalauth4ssp" cookie and redirects to SimpleSAMLphp.
4. SimpleSAMLphp loads drupalauth simplesaml-module for authentication checking, which checks "drupalauth4ssp" cookie.
4a. If cookie not present: deletes it and throws exception. If present: deletes it and redirects back to the site (posting authentication data.)

The **issue** is this:
- step 4 also throws an exception if the cookie fails a hash check. Great.
- step 2 also throws an exception if the cookie fails a hash check. Not great. Because
- \* the cookie is not even supposed to be set at that point. (Only the IdP sets it.)
- \* throwing this exception does not delete the cookie. Which means an old cookie (for a failed login attempt for a different user) exists 'forever' and all login attempts will fail.

My solution: do not throw an exception in step 2.
