### PR TITLE
PHP7.2 compatibility

### DIFF
--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -141,8 +141,8 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-    assert('is_array($info)');
-    assert('is_array($config)');
+    assert(is_array($info));
+    assert(is_array($config));
 
     /* Call the parent constructor first, as required by the interface. */
     parent::__construct($info, $config);
@@ -318,7 +318,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state) );
 
 		$attributes = $this->getUser();
 		if ($attributes !== NULL) {
@@ -390,7 +390,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 		/*
 		 * The redirect function never returns, so we never get this far.
 		 */
-		assert('FALSE');
+		assert(FALSE);
 	}
 
 
@@ -469,7 +469,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 		/*
 		 * The completeAuth-function never returns, so we never get this far.
 		 */
-		assert('FALSE');
+		assert(FALSE);
 	}
 
 
@@ -480,7 +480,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  The logout state array.
 	 */
 	public function logout(&$state) {
-    assert('is_array($state)');
+    assert(is_array($state));
 
     if (!session_id()) {
       /* session_start not called before. Do it here. */

--- a/lib/Auth/Source/UserPass.php
+++ b/lib/Auth/Source/UserPass.php
@@ -75,8 +75,8 @@ class sspmod_drupalauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassBa
      */
     public function __construct($info, $config)
     {
-        assert('is_array($info)');
-        assert('is_array($config)');
+        assert(is_array($info));
+        assert(is_array($config));
 
         /* Call the parent constructor first, as required by the interface. */
         parent::__construct($info, $config);
@@ -115,8 +115,8 @@ class sspmod_drupalauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassBa
      */
     protected function login($username, $password)
     {
-        assert('is_string($username)');
-        assert('is_string($password)');
+        assert(is_string($username));
+        assert(is_string($password));
 
         $this->bootDrupal();
 

--- a/lib/ConfigHelper.php
+++ b/lib/ConfigHelper.php
@@ -73,8 +73,8 @@ class sspmod_drupalauth_ConfigHelper {
 	 * @param string $location  The location of this configuration. Used for error reporting.
 	 */
 	public function __construct($config, $location) {
-		assert('is_array($config)');
-		assert('is_string($location)');
+		assert(is_array($config));
+		assert(is_string($location));
 
 		$this->location = $location;
 


### PR DESCRIPTION
SimpleSAMLphp 1.16 is compatible with PHP 7.2.
String arguments to assert() calls are deprecated in PHP 7.2. They're always (in our case) evaluating to a boolean expression. So we just need to 'assert' the unquoted boolean expression. This is exactly what SimpleSAMLphp itself has done too.

Feel free to rebase this onto whatever other fix branch - I am not attached to the php72 branch in my repo.

The same is necessary for PHP7. You can use the commit on the php72-7 branch in my repo for it... or rebase this commit but it does not apply cleanly. (You'll need to modify the 4 places in UserPass.php yourself.)