### PR TITLE
PHP7.2 compatibility (for 1.7.x / D7)

### DIFF
--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -318,7 +318,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert(is_array($state) );
+		assert(is_array($state));
 
 		$attributes = $this->getUser();
 		if ($attributes !== NULL) {

--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -141,8 +141,8 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-    assert('is_array($info)');
-    assert('is_array($config)');
+    assert(is_array($info));
+    assert(is_array($config));
 
     /* Call the parent constructor first, as required by the interface. */
     parent::__construct($info, $config);
@@ -318,7 +318,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  Information about the current authentication.
 	 */
 	public function authenticate(&$state) {
-		assert('is_array($state)');
+		assert(is_array($state) );
 
 		$attributes = $this->getUser();
 		if ($attributes !== NULL) {
@@ -390,7 +390,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 		/*
 		 * The redirect function never returns, so we never get this far.
 		 */
-		assert('FALSE');
+		assert(FALSE);
 	}
 
 
@@ -469,7 +469,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 		/*
 		 * The completeAuth-function never returns, so we never get this far.
 		 */
-		assert('FALSE');
+		assert(FALSE);
 	}
 
 
@@ -480,7 +480,7 @@ class sspmod_drupalauth_Auth_Source_External extends SimpleSAML_Auth_Source {
 	 * @param array &$state  The logout state array.
 	 */
 	public function logout(&$state) {
-    assert('is_array($state)');
+    assert(is_array($state));
 
     if (!session_id()) {
       /* session_start not called before. Do it here. */

--- a/lib/Auth/Source/UserPass.php
+++ b/lib/Auth/Source/UserPass.php
@@ -98,8 +98,8 @@ class sspmod_drupalauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassBa
 	 * @param array $config  Configuration.
 	 */
 	public function __construct($info, $config) {
-		assert('is_array($info)');
-		assert('is_array($config)');
+		assert(is_array($info));
+		assert(is_array($config));
 
 		/* Call the parent constructor first, as required by the interface. */
 		parent::__construct($info, $config);
@@ -148,8 +148,8 @@ class sspmod_drupalauth_Auth_Source_UserPass extends sspmod_core_Auth_UserPassBa
 	 * @return array  Associative array with the users attributes.
 	 */
 	protected function login($username, $password) {
-		assert('is_string($username)');
-		assert('is_string($password)');
+		assert(is_string($username));
+		assert(is_string($password));
 
 		// authenticate the user
 		$drupaluid = user_authenticate($username, $password);

--- a/lib/ConfigHelper.php
+++ b/lib/ConfigHelper.php
@@ -73,8 +73,8 @@ class sspmod_drupalauth_ConfigHelper {
 	 * @param string $location  The location of this configuration. Used for error reporting.
 	 */
 	public function __construct($config, $location) {
-		assert('is_array($config)');
-		assert('is_string($location)');
+		assert(is_array($config));
+		assert(is_string($location));
 
 		$this->location = $location;
 


### PR DESCRIPTION
Cloned from #40 whch was merge into master / D8.

SimpleSAMLphp 1.16 is compatible with PHP 7.2.
String arguments to assert() calls are deprecated in PHP 7.2. They're always (in our case) evaluating to a boolean expression. So we just need to 'assert' the unquoted boolean expression. This is exactly what SimpleSAMLphp itself has done too.
