### PR TITLE
Fixes bug affecting Drupal boot.

### DIFF
--- a/lib/DrupalHelper.php
+++ b/lib/DrupalHelper.php
@@ -19,7 +19,7 @@ class DrupalHelper
     public function bootDrupal($drupalRoot)
     {
         $autoloader = require_once $drupalRoot . '/autoload.php';
-        $request = new Request();
+        $request = Request::createFromGlobals();
         $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);
         $kernel->boot();
         $kernel->loadLegacyIncludes();


### PR DESCRIPTION
# Changes

- Fixes a bug with the DrupalHelper boot method where the host would be returned as an empty string during an authsource test. This fell outside the scope of the trusted host patterns, as well as would have incorrectly loaded the database from the default site when, in my instance, it should have been loading the database from another site.