### PR TITLE
I-46: Ensured Drupal is bootstrapped from its root directory.

### DIFF
--- a/lib/DrupalHelper.php
+++ b/lib/DrupalHelper.php
@@ -26,9 +26,12 @@ class DrupalHelper
           'HTTP_HOST' => $current_request->getHost(),
         ];
         $request = new Request([], [], [], [], [], $server);
+        $originalDir = getcwd();
+        chdir($drupalRoot);
         $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);
         $kernel->boot();
         $kernel->loadLegacyIncludes();
+        chdir($originalDir);
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/drupalauth/simplesamlphp-module-drupalauth/issues/46