### PR TITLE
I-48: Ensured trusted host settings checks do not fail

### DIFF
--- a/lib/DrupalHelper.php
+++ b/lib/DrupalHelper.php
@@ -19,7 +19,13 @@ class DrupalHelper
     public function bootDrupal($drupalRoot)
     {
         $autoloader = require_once $drupalRoot . '/autoload.php';
-        $request = new Request();
+        // Inherit the current request's HTTP host to respect trusted hosts
+        // settings.
+        $current_request = Request::createFromGlobals();
+        $server = [
+          'HTTP_HOST' => $current_request->getHost(),
+        ];
+        $request = new Request([], [], [], [], [], $server);
         $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);
         $kernel->boot();
         $kernel->loadLegacyIncludes();


### PR DESCRIPTION
Fix for https://github.com/drupalauth/simplesamlphp-module-drupalauth/issues/48