### PR TITLE
Update suggested login URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Configure the authentication source by putting following code into `simplesamlph
  'drupal_logout_url' => 'https://www.example.com/drupal/user/logout',
 
  // the URL of the Drupal login page
- 'drupal_login_url' => 'https://www.example.com/drupal/user',
+ 'drupal_login_url' => 'https://www.example.com/drupal/user/login',
 
  // Which attributes should be retrieved from the Drupal site.
     'attributes' => array(


### PR DESCRIPTION
If the `/user` path is set a login URL in the `drupal-userpass` configuration, a redirect will be automatically performed to `/user/login`, which will make the URL lose the `RelayState` query string parameter. Configuring the `/user/login` path directly bypasses this issue, so I think docs should be updated to reflect that.