### PR TITLE
Fix #58: Database connection is not defined if default site is not IDP

### DIFF
--- a/lib/DrupalHelper.php
+++ b/lib/DrupalHelper.php
@@ -19,13 +19,7 @@ class DrupalHelper
     public function bootDrupal($drupalRoot)
     {
         $autoloader = require_once $drupalRoot . '/autoload.php';
-        // Inherit the current request's HTTP host to respect trusted hosts
-        // settings.
-        $current_request = Request::createFromGlobals();
-        $server = [
-          'HTTP_HOST' => $current_request->getHost(),
-        ];
-        $request = new Request([], [], [], [], [], $server);
+        $request = Request::createFromGlobals();
         $originalDir = getcwd();
         chdir($drupalRoot);
         $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);


### PR DESCRIPTION
When Drupal initialize settings, it try to get the site path according to the $request->server->get('SCRIPT_NAME') or $request->server->get('SCRIPT_FILENAME'). Check below findSitePath function. 
```

public static function findSitePath(Request $request, $require_settings = TRUE, $app_root = NULL) {
    if (static::validateHostname($request) === FALSE) {
      throw new BadRequestHttpException();
    }

    if ($app_root === NULL) {
      $app_root = static::guessApplicationRoot();
    }

    // Check for a simpletest override.
    if ($test_prefix = drupal_valid_test_ua()) {
      $test_db = new TestDatabase($test_prefix);
      return $test_db->getTestSitePath();
    }

    // Determine whether multi-site functionality is enabled.
    if (!file_exists($app_root . '/sites/sites.php')) {
      return 'sites/default';
    }

    // Otherwise, use find the site path using the request.
    $script_name = $request->server->get('SCRIPT_NAME');
    if (!$script_name) {
      $script_name = $request->server->get('SCRIPT_FILENAME');
    }
    $http_host = $request->getHttpHost();

    $sites = [];
    include $app_root . '/sites/sites.php';

    $uri = explode('/', $script_name);
    $server = explode('.', implode('.', array_reverse(explode(':', rtrim($http_host, '.')))));
    for ($i = count($uri) - 1; $i > 0; $i--) {
      for ($j = count($server); $j > 0; $j--) {
        $dir = implode('.', array_slice($server, -$j)) . implode('.', array_slice($uri, 0, $i));
        if (isset($sites[$dir]) && file_exists($app_root . '/sites/' . $sites[$dir])) {
          $dir = $sites[$dir];
        }
        if (file_exists($app_root . '/sites/' . $dir . '/settings.php') || (!$require_settings && file_exists($app_root . '/sites/' . $dir))) {
          return "sites/$dir";
        }
      }
    }
    return 'sites/default';
  }

```
Inside the bootDrupal function, I'm not sure why it's using $requrest instead of $current_request directly. But when I change the $request to $current_request, it's working now.

```
    public function bootDrupal($drupalRoot)
    {
        $autoloader = require_once $drupalRoot . '/autoload.php';
        // Inherit the current request's HTTP host to respect trusted hosts
        // settings.
        $current_request = Request::createFromGlobals();
        $server = [
          'HTTP_HOST' => $current_request->getHost(),
        ];
        $request = new Request([], [], [], [], [], $server);
        $originalDir = getcwd();
        chdir($drupalRoot);
        $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);
        $kernel->boot();
        $kernel->loadLegacyIncludes();
        chdir($originalDir);
    }
```