### PR TITLE
Crypt::hashEquals was deprecated from Drupal 9, adding the hash_equal…

### DIFF
--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -136,7 +136,7 @@ class External extends Source
                     $uid,
                     $this->config->getCookieSalt() . \Drupal::service('private_key')->get()
                 );
-                if (!hash_equals($hash, $cookie_hash)) { 
+                if (!hash_equals($hash, $cookie_hash)) {
                     throw new Exception(
                         'Cookie hash invalid. This indicates either tampering or an out of date drupal4ssp module.'
                     );

--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -136,7 +136,7 @@ class External extends Source
                     $uid,
                     $this->config->getCookieSalt() . \Drupal::service('private_key')->get()
                 );
-                if (!Crypt::hashEquals($hash, $cookie_hash)) {
+                if (!hash_equals($hash, $cookie_hash)) { 
                     throw new Exception(
                         'Cookie hash invalid. This indicates either tampering or an out of date drupal4ssp module.'
                     );


### PR DESCRIPTION
I was testing the module for a Drupal 9 website and there is an error with the Crypt::hashEquals on line 139 on the External.php class.

It turns out the Crypt::hashEquals was deprecated in favour of the hash_equals() function.
More info here: https://www.drupal.org/node/3054488




