### PR TITLE
Drupal 9 compatibility - handle removed function

### DIFF
--- a/lib/Auth/Source/External.php
+++ b/lib/Auth/Source/External.php
@@ -136,7 +136,7 @@ class External extends Source
                     $uid,
                     $this->config->getCookieSalt() . \Drupal::service('private_key')->get()
                 );
-                if (!Crypt::hashEquals($hash, $cookie_hash)) {
+                if (!hash_equals($hash, $cookie_hash)) {
                     throw new Exception(
                         'Cookie hash invalid. This indicates either tampering or an out of date drupal4ssp module.'
                     );


### PR DESCRIPTION
Crypt::hashEquals was Deprecated in 8.8 and has been removed in Drupal 9. 

Recommended solution is to use PHP's built in hash_equals function instead. 

Without this login doesn't complete.

Relevant notice is https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Utility%21Crypt.php/function/Crypt%3A%3AhashEquals/8.9.x