### PR TITLE
Prevent error when Drupal autoloader has been required before

### DIFF
--- a/lib/DrupalHelper.php
+++ b/lib/DrupalHelper.php
@@ -18,7 +18,7 @@ class DrupalHelper
      */
     public function bootDrupal($drupalRoot)
     {
-        $autoloader = require_once $drupalRoot . '/autoload.php';
+        $autoloader = require $drupalRoot . '/autoload.php';
         $request = Request::createFromGlobals();
         $originalDir = getcwd();
         chdir($drupalRoot);


### PR DESCRIPTION
Prevent error when Drupal autoloader has been required before.

It is the same solution as #65 and #74 but simpler.

Solves #64.