### PR TITLE
Support authentication by mail

### DIFF
--- a/lib/Auth/Source/UserPass.php
+++ b/lib/Auth/Source/UserPass.php
@@ -109,6 +109,19 @@ class UserPass extends UserPassBase
         $drupalHelper = new DrupalHelper();
         $drupalHelper->bootDrupal($this->config->getDrupalroot());
 
+        // support login by mail 
+        $users = \Drupal::entityTypeManager()->getStorage('user')
+            ->loadByProperties(['name' => $username]);
+        $user = $users ? reset($users) : FALSE;
+        if(!$user) {
+            // user was not found, assume mail was entered instead username 
+            $users = \Drupal::entityTypeManager()->getStorage('user')
+                ->loadByProperties(['mail' => $username]);
+            if($user = $users ? reset($users) : FALSE){
+                $username = $user->getDisplayName();
+            }
+        }
+
         /* @value \Drupal\user\UserAuth $userAuth */
         $userAuth = \Drupal::service('user.auth');
 


### PR DESCRIPTION
We're using Drupal in conjunction with the module **login_emailusername**, which allows our users to login with their mail address as well.

In order to allow this here as well, we also check, whether there was a valid mail/password combination.

I usually don't do php, so consider this as a merely draft - though functional as far as I can see 😄 
Probably there should be a setting to enable this as well. 🤔 
