### PR TITLE
Bootstrap Drupal correctly from inside SimpleSAMLphp

### DIFF
--- a/src/DrupalHelper.php
+++ b/src/DrupalHelper.php
@@ -25,7 +25,6 @@ class DrupalHelper
         $originalDir = getcwd();
         chdir($drupalRoot);
         $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);
-        $kernel->invalidateContainer();
         $kernel->boot();
         $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('<none>'));
         $request->attributes->set(RouteObjectInterface::ROUTE_NAME, '<none>');

--- a/src/DrupalHelper.php
+++ b/src/DrupalHelper.php
@@ -3,7 +3,9 @@
 namespace SimpleSAML\Module\drupalauth;
 
 use Drupal\Core\DrupalKernel;
+use Drupal\Core\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
 
 class DrupalHelper
 {
@@ -13,6 +15,8 @@ class DrupalHelper
      * Boot Drupal.
      *
      * @param string $drupalRoot Path to Drupal root.
+     *
+     * @see \Drupal\Core\Test\FunctionalTestSetupTrait::initKernel()
      */
     public function bootDrupal(string $drupalRoot)
     {
@@ -21,8 +25,11 @@ class DrupalHelper
         $originalDir = getcwd();
         chdir($drupalRoot);
         $kernel = DrupalKernel::createFromRequest($request, $autoloader, 'prod', true, $drupalRoot);
+        $kernel->invalidateContainer();
         $kernel->boot();
-        $kernel->loadLegacyIncludes();
+        $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('<none>'));
+        $request->attributes->set(RouteObjectInterface::ROUTE_NAME, '<none>');
+        $kernel->preHandle($request);
         chdir($originalDir);
     }
 


### PR DESCRIPTION
This was previously reported in #75 but closed as outdated, however it is still an issue.

When certain caches are cold or stale, it is possible for them to be rebuilt during a request that is wrapped by SimpleSAMLphp instead of Drupal's own index.php. However when this happens, the cache is not rebuilt correctly and are missing critical data. This then results in various errors related to missing fields on the Drupal site such as:
```
Attempted to create an instance of field with name field_XXX on entity type profile when the field storage does not exist.
Attempted to create an instance of field with name body on entity type block_content when the field storage does not exist.
Field layout_builder__layout is unknown.
```
or errors with missing plugins:
```
The "field_item:language" plugin does not exist. Valid plugin IDs for Drupal\Core\TypedData\TypedDataManager are: ...
```

This is because `DrupalHelper::bootDrupal()` does not fully bootstrap Drupal correctly before calling core services which may go on to initialise caches. In particular the `DrupalKernel::preHandle()` method is not called which is responsible for loading all modules, which causes the rebuilt caches to skip items from those modules and cause the errors later down the line.

As per the comment if you look at `FunctionalTestSetupTrait::initKernel()` or even `/authorize.php` you will see the correct way of partially bootstrapping Drupal without calling `DrupalKernel::handle()` is to call `preHandle()` (which calls `loadLegacyIncludes()` but also does a bit more).
