### PR TITLE
Restore SimpleSAMLphp exception handler

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,0 @@
-20131210 Steve Moitozo <steve_moitozo@sil.org>
-
-  Resolved security issue (defect #9 - identified by alanabarrett0).
-
-    Expanded the use of the salted hash to ensure that an attacker cannot change the uid of the authenticated Drupal user by manipulating the value of a cookie.
-
-    Modified files:
-      drupal_module/drupalauth4ssp/drupalauth4ssp.module - concatenate uid with salt before hashing
-      lib/Auth/Source/External.php - concatenate uid with salt before hashing and minor adjustments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+See the main [README.md](./README.md#branch-and-version-naming) for the details about version naming.
+
+
+## [Unreleased]
+
+### Fixed
+- Restored SimpleSAMLphp exception handler (#29, #35)
+
+
+## [2.10.0-rc.1]

--- a/src/DrupalHelper.php
+++ b/src/DrupalHelper.php
@@ -24,6 +24,8 @@ class DrupalHelper
         $kernel->boot();
         $kernel->loadLegacyIncludes();
         chdir($originalDir);
+        \restore_exception_handler();
+        \restore_error_handler();
     }
 
     /**


### PR DESCRIPTION
This was raised multiple times, in the linked in the changelog issues, yet was completely overlooked by me.