### PR TITLE
Alter attributes event - Reroll of pull/95

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,11 @@
     "phpunit/phpunit": "^9.0 | ^10.0",
     "squizlabs/php_codesniffer": "^3.0"
   },
+  "autoload": {
+    "psr-4": {
+      "SimpleSAML\\Module\\drupalauth\\": "src/"
+    }
+  },
   "autoload-dev": {
     "classmap": ["src/", "tests/"]
   },

--- a/src/DrupalHelper.php
+++ b/src/DrupalHelper.php
@@ -90,8 +90,7 @@ class DrupalHelper
         $event = new SetAttributesEvent($this, $drupaluser, $requested_attributes, $attributes);
         $event_dispatcher = \Drupal::service('event_dispatcher');
         $event_dispatcher->dispatch($event, SetAttributesEvent::EVENT_NAME);
-        $attributes = $event->getAttributes();
-        return $attributes;
+        return $event->getAttributes();
     }
 
     /**

--- a/src/DrupalHelper.php
+++ b/src/DrupalHelper.php
@@ -4,6 +4,7 @@ namespace SimpleSAML\Module\drupalauth;
 
 use Drupal\Core\DrupalKernel;
 use Drupal\Core\Routing\RouteObjectInterface;
+use SimpleSAML\Module\drupalauth\Event\SetAttributesEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 
@@ -46,7 +47,7 @@ class DrupalHelper
         $forbiddenAttributes = $this->forbiddenAttributes;
 
         if (empty($requested_attributes)) {
-            return $this->getAllAttributes($drupaluser, $forbiddenAttributes);
+            $attributes = $this->getAllAttributes($drupaluser, $forbiddenAttributes);
         } else {
             foreach ($requested_attributes as $attribute) {
                 $field_name = $attribute['field_name'];
@@ -86,7 +87,10 @@ class DrupalHelper
                 }
             }
         }
-
+        $event = new SetAttributesEvent($this, $drupaluser, $requested_attributes, $attributes);
+        $event_dispatcher = \Drupal::service('event_dispatcher');
+        $event_dispatcher->dispatch($event, SetAttributesEvent::EVENT_NAME);
+        $attributes = $event->getAttributes();
         return $attributes;
     }
 
@@ -124,7 +128,7 @@ class DrupalHelper
         return $attributes;
     }
 
-    protected function getPropertyName($attribute_definition)
+    public function getPropertyName($attribute_definition)
     {
         $property_name = 'value';
         if (!empty($attribute_definition['field_property'])) {
@@ -134,7 +138,7 @@ class DrupalHelper
         return $property_name;
     }
 
-    protected function getAttributeName($attribute_definition)
+    public function getAttributeName($attribute_definition)
     {
         if (!empty($attribute_definition['attribute_name'])) {
             return $attribute_definition['attribute_name'];

--- a/src/Event/SetAttributesEvent.php
+++ b/src/Event/SetAttributesEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SimpleSAML\Module\drupalauth\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\user\UserInterface;
+use SimpleSAML\Module\drupalauth\DrupalHelper;
+
+/**
+ * Event that is fired after SAML attributes are set
+ */
+class SetAttributesEvent extends Event
+{
+    public const EVENT_NAME = 'simplesamlphp_drupalauth_set_attributes';
+
+
+    /**
+     * Contstruct the event.
+     *
+     * @param \SimpleSAML\Module\drupalauth\DrupalHelper $drupalHelper
+     * @param \Drupal\user\UserInterface $user
+     * @param array $attributes
+     */
+    public function __construct(
+        protected readonly DrupalHelper $drupalHelper,
+        protected readonly UserInterface $user,
+        protected readonly array $requestedAttributes,
+        protected array $attributes
+    ) {
+    }
+
+    /**
+     * Get the drupal helper.
+     */
+    public function getDrupalHelper(): DrupalHelper
+    {
+        return $this->drupalHelper;
+    }
+
+    /**
+     * Get the requested attributes.
+     */
+    public function getRequestedAttributes(): array
+    {
+        return $this->requestedAttributes;
+    }
+
+    /**
+     * Get user who logged in.
+     */
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    /**
+     * Get the attributes set.
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Set the attributes.
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+}


### PR DESCRIPTION
Adds SetAttributesEvent Event that happens after attributes are created. This allows us to update the attributes in a Drupal Module by subscribing to this event.

Also changes two methods in the Drupal Helper from protected to public so they can be used via the Event Subscriber.

Reroll required due to 6ad28dda12a6f3b978eaefd7ff8ad1ab77f8d8bd which also adds Aliases/Imports in a way that prevents an automatic merge.